### PR TITLE
Test Messages Model

### DIFF
--- a/client/admin/admin-controller.js
+++ b/client/admin/admin-controller.js
@@ -15,4 +15,5 @@
 
 }(angular.module('yg.admin.controllers', ['yg.admin.controllers.reminders',
                                           'yg.admin.controllers.test-dates',
+                                          'yg.admin.controllers.test-messages',
                                           'yg.admin.controllers.faqs'])));

--- a/client/admin/app.js
+++ b/client/admin/app.js
@@ -31,6 +31,11 @@
         templateUrl: 'templates/test-dates.html',
         controller: 'AdminTestDatesController'
       })
+      .state('test-messages', {
+        url: '/test-messages',
+        templateUrl: 'templates/test-messages.html',
+        controller: 'AdminTestMessagesController'
+      })
       .state('faqs', {
         url: '/faqs',
         templateUrl: 'templates/faqs.html',

--- a/client/admin/controllers/test-messages.js
+++ b/client/admin/controllers/test-messages.js
@@ -19,7 +19,26 @@
       $scope.data.actDetail = respData.actDetail;
     };
 
+    $scope.save = function(data) {
+      
+      $scope.$broadcast('show-errors-check-validity');
+      if ($scope.testMessageForm.$invalid) {
+        toastr.error('Please make sure all fields are complete.');
+        return;
+      }
+
+      YadaAPI.testMessages.put(data._id, data).then(function(resp) {
+        toastr.success('Test Messages Saved Successfully');
+      }, function(err) {
+        toastr.error('Save failed');
+        console.log(err);
+      });
+
+    };
+
     $scope.getTestMessages();
+
+      
 
   };
 

--- a/client/admin/controllers/test-messages.js
+++ b/client/admin/controllers/test-messages.js
@@ -1,0 +1,12 @@
+(function(app) {
+  
+  'use strict';
+
+  var AdminTestMessagesController = function($scope, YadaAPI) {
+
+  };
+
+
+  app.controller('AdminTestMessagesController', ['$scope', 'YadaAPI', AdminTestMessagesController]);
+
+}(angular.module('yg.admin.controllers.test-messages', [])));

--- a/client/admin/controllers/test-messages.js
+++ b/client/admin/controllers/test-messages.js
@@ -4,8 +4,24 @@
 
   var AdminTestMessagesController = function($scope, YadaAPI) {
 
-  };
+    $scope.data = {};
 
+    $scope.getTestMessages = function() {
+      YadaAPI.testMessages.get().then(populate, function(err) {console.log(err);});
+    };
+
+    var populate = function(resp) {
+      var respData = resp.data[0];
+      $scope.data._id = respData._id;
+      $scope.data.satMessage = respData.satMessage;
+      $scope.data.satDetail = respData.satDetail;
+      $scope.data.actMessage = respData.actMessage;
+      $scope.data.actDetail = respData.actDetail;
+    };
+
+    $scope.getTestMessages();
+
+  };
 
   app.controller('AdminTestMessagesController', ['$scope', 'YadaAPI', AdminTestMessagesController]);
 

--- a/client/admin/index.html
+++ b/client/admin/index.html
@@ -38,6 +38,7 @@
           <ul class="nav navbar-nav">
             <li ng-class="currentTab === '/reminders' ? 'active' : ''"><a ui-sref="reminders">Reminders</a></li>
             <li ng-class="currentTab === '/test-dates' ? 'active' : ''"><a ui-sref="test-dates">Test Dates</a></li>
+            <li ng-class="currentTab === '/test-messages' ? 'active' : ''"><a ui-sref="test-messages">Test Messages</a></li>
             <li ng-class="currentTab === '/faqs' ? 'active' : ''"><a ui-sref="faqs">FAQs</a></li>
           </ul>
           <!-- uncomment below when functionality is ready -->
@@ -80,6 +81,7 @@
   <script src="admin-controller.js"></script>
   <script src="controllers/reminders.js"></script>
   <script src="controllers/test-dates.js"></script>
+  <script src="controllers/test-messages.js"></script>
   <script src="controllers/faqs.js"></script>
   <script src="directives.js"></script>
   <script src="directives/show-errors.js"></script>

--- a/client/admin/templates/test-messages.html
+++ b/client/admin/templates/test-messages.html
@@ -1,0 +1,31 @@
+<div class="container">
+  <div class="row">
+    <h2>Test Messages</h2>
+    <p class="text-info">
+      Type <code>%TESTDATE%</code> and <code>%REGDATE%</code> to display the
+      test and registration date for the test being displayed.
+    </p>
+    <form name="testMessageForm" novalidate>
+      <div class="form-group" show-errors>
+        <label class="control-label" for="satMessage">SAT Message:</label>
+        <input type="text" ng-model="data.satMessage" name="satMessage"
+               class="form-control" id="satMessage" required/>
+      </div>
+      <div class="form-group" show-errors>
+        <label class="control-label" for="satDetail">SAT Detail:</label>
+        <textarea ng-model="data.satDetail" class="form-control" name="satDetail"
+                  id="satDetail" rows="3" required></textarea>
+      </div>
+      <div class="form-group" show-errors>
+        <label class="control-label" for="actMessage">ACT Message:</label>
+        <input type="text" ng-model="data.actMessage" name="actMessage"
+               class="form-control" id="actMessage" required/>
+      </div>
+      <div class="form-group" show-errors>
+        <label class="control-label" for="actDetail">ACT Detail:</label>
+        <textarea ng-model="data.actDetail" class="form-control" name="actDetail"
+                  id="actDetail" rows="3" required></textarea>
+      </div>
+      <button class="btn btn-primary" ng-click="save(data)">Save</button>
+  </div>
+</div>

--- a/client/common/services/apiService.js
+++ b/client/common/services/apiService.js
@@ -42,6 +42,16 @@
       return $http.delete('/api/test-dates/' + id);
     };
     
+    yadaAPI.testMessages = {};
+
+    yadaAPI.testMessages.get = function() {
+      return $http.get('/api/test-messages');
+    };
+
+    yadaAPI.testMessages.put = function(id, data) {
+      return $http.put('/api/test-messages/' + id, data);
+    };
+
     yadaAPI.faqs = {};
 
     yadaAPI.faqs.get = function() {

--- a/client/common/services/utilsService.js
+++ b/client/common/services/utilsService.js
@@ -6,6 +6,16 @@
   
     var utils = {};
 
+    /**
+     * Adds key/value pairs to an array of objects, with an optional filter
+     * Returns an array of objects
+     * @param {object[]} data - an array of data objects to be modified
+     * @param {string} key - the name of the key to be added
+     * @param {string} value - the value of the key to be added
+     * @param {function} filter - a function to use for filtering. Function must take
+     *                            one parameter to represent the data object being filtered.
+     *                            Function must evaluate to true or false.
+     */
     utils.addKeyValue = function(data, key, value, filter) {
       data = data.map(function(d) {
         if (typeof filter === 'function') {
@@ -20,6 +30,12 @@
       return data;
     };
 
+    /**
+     * Sorts an array of objects
+     * Returns an array of objects
+     * @param {object[]} data = an array of objects
+     * @param {string} sortKey - the key on which to sort
+     */
     utils.sortBy = function(data, sortKey) {
       return data.sort(function (a, b) {
         if (a[sortKey] > b[sortKey]) {
@@ -32,6 +48,12 @@
       });
     };
     
+    /**
+     * Groups an array of objects into into a two-dimensional grouped array
+     * Returns a two-dimension array of objects.
+     * @param {object[]} - an array of objects
+     * @param {string} propToGroupBy - the property to group the object by
+     */
     utils.groupBy = function(arrayOfObjects, propToGroupBy) {
       var groupArray = [],
           match;
@@ -66,6 +88,14 @@
       return groupArray;
     };
 
+    /**
+     * Parses text, replacing  %VARIABLE% placeholders with values.
+     * Returns a string.
+     * @param {string} - Text to be parsed
+     * @param {object...} - One or more objects containing the variable and the value
+     *   @property {variable} - The variable to be replaced
+     *   @property {value} - The value of the variable
+     */
     utils.parseVars = function(string, replacementObj) {
       var replacementObjs = [];
       for (var i = 1; i < arguments.length; i++) {
@@ -81,6 +111,11 @@
       return string;
     };
 
+    /**
+     * Formats a date in M/D/YYYY format.
+     * Returns a string.
+     * @param {string} dateString - a string representing a valid date
+     */
     utils.formatDate = function(dateString) {
       var date = new Date(dateString); 
       var d = date.getDate();

--- a/client/common/services/utilsService.js
+++ b/client/common/services/utilsService.js
@@ -6,11 +6,18 @@
   
     var utils = {};
 
-    utils.addKeyValue = function(data, key, value) {
-      return data.map(function(d) {
-        d[key] = value;
+    utils.addKeyValue = function(data, key, value, filter) {
+      data = data.map(function(d) {
+        if (typeof filter === 'function') {
+          if (filter(d)) {
+            d[key] = value;
+          }
+        } else {
+          d[key] = value;
+        }
         return d;
       });
+      return data;
     };
 
     utils.sortBy = function(data, sortKey) {
@@ -59,8 +66,15 @@
       return groupArray;
     };
 
-    utils.parseVars = function(string, school, date) {
-      var replacements = {'%SCHOOL%': school, '%DATE%': utils.formatDate(date)};
+    utils.parseVars = function(string, replacementObj) {
+      var replacementObjs = [];
+      for (var i = 1; i < arguments.length; i++) {
+        replacementObjs.push(arguments[i]);
+      }
+      var replacements = {};
+      replacementObjs.forEach(function(replacementObj) {
+        replacements[replacementObj.variable] = replacementObj.value;
+      });
       string = string.replace(/%\w+%/g, function(all) {
         return replacements[all] || all;
       });

--- a/client/common/services/utilsService.js
+++ b/client/common/services/utilsService.js
@@ -89,10 +89,35 @@
       return m + '/' + d + '/' + y;
     };
       
+    /**
+     * Gets data from multiple models
+     * @param {object} apiService - the api service object to use
+     * @param {string[]} models - an array of strings of the names of the models to get
+     * @param {function} callback - a function to run after all models have been retrieved, must take a data argument.
+     * @param {object} data - an object to hold the data collected.
+     */
+    utils.getModels = function(apiService, models, callback, data) {
+      //debugger;
+
+      data = data || {};
+
+      if (models.length === 0) {
+        callback(data);
+      } else {
+        var model = models.pop();
+        apiService[model].get().then(function(resp) {
+          data[model] = resp.data;
+          utils.getModels(apiService, models, callback, data);
+        });
+      }
+
+    };
+
    return utils;
   
   };
   
+                                                                                                 
   app.factory('Utils', [utilService]);
 
 }(angular.module('yg.common.services.utils', [])));

--- a/client/root/root-controller.js
+++ b/client/root/root-controller.js
@@ -4,41 +4,15 @@
   var RootController = function ($scope, YadaAPI, Utils, ReminderService) {
     $scope.reminders = [];
     $scope.dt = new Date();
-    var reminderData, 
-        testDateData,
-        testMessageData,
-        allData,
-        reminderMessages,
-        groupedMessages;
 
-    var getTestMessageData = function() {
-      YadaAPI.testMessages.get().then(function(resp) {
-        testMessageData = resp.data[0];
-        $scope.buildReminderList();
-      });
-    };
-
-    var getTestDateData = function() {
-      YadaAPI.testDates.get().then(function(resp) {
-        testDateData = resp.data;
-        getTestMessageData();
-      }, function(err) {console.log(err);});
-    };
-
-    var getReminderData = function() {
-      YadaAPI.reminders.get().then(function(resp) {
-        reminderData = resp.data;
-        getTestDateData();
-      }, function(err) {console.log(err);});
-    };
-
-    $scope.getReminders = function(formData) {
-      $scope.formData = formData;
-      getReminderData();
-    };
-
-    $scope.buildReminderList = function() {
+    $scope.buildReminderList = function(data) {
       var currentDate = new Date();
+      var reminderData = data.reminders,
+          testDateData = data.testDates,
+          testMessageData = data.testMessages[0],
+          allData,
+          reminderMessages,
+          groupedMessages;
       reminderData = ReminderService.flattenTimeframes(reminderData);
       reminderData = ReminderService.generateSortDates(reminderData, 'timeframes', $scope.formData.dt);
       testDateData = ReminderService.generateSortDates(testDateData, 'registrationDate');
@@ -63,7 +37,11 @@
         dateGroup.members = Utils.groupBy(dateGroup.members, 'category');
       });
       $scope.reminders = groupedMessages;
+    };
 
+    $scope.getReminders = function(formData) {
+      $scope.formData = formData;
+      Utils.getModels(YadaAPI, ['reminders', 'testDates', 'testMessages'], $scope.buildReminderList);
     };
 
     $scope.format = 'M/d/yyyy';

--- a/client/root/root-controller.js
+++ b/client/root/root-controller.js
@@ -6,14 +6,22 @@
     $scope.dt = new Date();
     var reminderData, 
         testDateData,
+        testMessageData,
         allData,
         reminderMessages,
         groupedMessages;
 
+    var getTestMessageData = function() {
+      YadaAPI.testMessages.get().then(function(resp) {
+        testMessageData = resp.data[0];
+        $scope.buildReminderList();
+      });
+    };
+
     var getTestDateData = function() {
       YadaAPI.testDates.get().then(function(resp) {
         testDateData = resp.data;
-        $scope.buildReminderList();
+        getTestMessageData();
       }, function(err) {console.log(err);});
     };
 
@@ -35,6 +43,18 @@
       reminderData = ReminderService.generateSortDates(reminderData, 'timeframes', $scope.formData.dt);
       testDateData = ReminderService.generateSortDates(testDateData, 'registrationDate');
       testDateData = Utils.addKeyValue(testDateData, 'category', 'Testing');
+      testDateData = Utils.addKeyValue(testDateData, 'message', testMessageData.satMessage, function(msg) {
+        return msg.testType === 'SAT';
+      });
+      testDateData = Utils.addKeyValue(testDateData, 'detail', testMessageData.satDetail, function(msg) {
+        return msg.testType === 'SAT';
+      });
+      testDateData = Utils.addKeyValue(testDateData, 'message', testMessageData.actMessage, function(msg) {
+        return msg.testType === 'ACT';
+      });
+      testDateData = Utils.addKeyValue(testDateData, 'detail', testMessageData.actDetail, function(msg) {
+        return msg.testType === 'ACT';
+      });
       allData = reminderData.concat(testDateData);
       allData = Utils.sortBy(allData, 'sortDate');
       reminderMessages = ReminderService.generateMessages(allData, $scope.formData.schoolName, $scope.formData.dt, currentDate);

--- a/client/root/services/reminderService.js
+++ b/client/root/services/reminderService.js
@@ -6,6 +6,11 @@
     
     var reminderService = {};
 
+    /**
+     * Splits reminders with multiple timeframes up into separate reminders with one timeframe
+     * Returns an array of objects.
+     * @param {object[]} reminders - an array of reminder objects
+     */
     reminderService.flattenTimeframes = function (reminders) {
       var flattenedReminders = [];
       reminders.forEach(function (reminder) {
@@ -23,6 +28,13 @@
       return flattenedReminders;
     };
 
+    /**
+     * Generates a sortDate key on a reminder object
+     * Returns an array of objects
+     * @param {object[]} data - an array of reminder objects
+     * @param {string} originKey - the timeframe key used to generate the sortdates
+     * @param {date} date - a JavaScript date object representing the student-selected date
+     */
     reminderService.generateSortDates = function(data, originKey, date) {
       return data.map(function(d) {
         if (d[originKey].match(/^\d+$/)) {
@@ -45,6 +57,14 @@
       });
     };
 
+    /**
+     * Generates reminder message objects
+     * Returns an array of objects
+     * @param {object[]} reminderData - an array of reminder objects
+     * @param {string} school - the name of the school passed in by the user
+     * @param {date} dueDate - a JavaScript date object representing the student-select due date
+     * @param {date} currentDate - a JavaScript date object representing the current date
+     */
     reminderService.generateMessages = function(reminderData, school, dueDate, currentDate) {
       var messages = [];
       reminderData.forEach(function(reminder) {
@@ -90,6 +110,12 @@
       return messages;
     };
 
+    /**
+     * Calculates the date X amount of days before the due due
+     * Returns a string representation of the calculated date
+     * @param {number} timeframe - the number of dates before the due date
+     * @param {date} date - a JavaScript date object representing the due date
+     */
     reminderService.calcDate = function(timeframe, date) {
       var newDate = angular.copy(date);
       newDate.setDate(newDate.getDate() - timeframe);

--- a/client/root/services/reminderService.js
+++ b/client/root/services/reminderService.js
@@ -49,6 +49,7 @@
       var messages = [];
       reminderData.forEach(function(reminder) {
         var message = {};
+        console.log(reminder);
         if (reminder.category === 'Testing') {
           var registrationDate = new Date (reminder.registrationDate);
           var testDate = new Date (reminder.testDate);
@@ -57,9 +58,10 @@
             message.category = reminder.category;
             message.date = 'By ' + Utils.formatDate(reminder.sortDate);
             message.name = 'Register for the ' + reminder.testType + ' test';
-            message.message = 'If you are planning on taking the ' + reminder.testType + ' test on ' +
-              Utils.formatDate(reminder.testDate) + ', you must register by ' + Utils.formatDate(registrationDate) + '.';
-            message.detail = 'Detailed message about registering for tests to go here';
+            var parseTestDateVar = {variable:'%TESTDATE%', value: Utils.formatDate(testDate)};
+            var parseRegDateVar = {variable: '%REGDATE%', value: Utils.formatDate(registrationDate)};
+            message.message = Utils.parseVars(reminder.message, parseTestDateVar, parseRegDateVar);
+            message.detail = Utils.parseVars(reminder.detail, parseTestDateVar, parseRegDateVar);
             messages.push(message);
           }
         } else {
@@ -73,12 +75,14 @@
           } else {
             message.date = 'By ' + Utils.formatDate(reminder.sortDate);
           }
+          var parseSchoolVar = {variable: '%SCHOOL%', value: school};
+          var parseDateVar = {variable: '%DATE%', value: Utils.formatDate(reminder.sortDate)};
           if (currentDate < messageDate) {
-            message.message = Utils.parseVars(reminder.message, school, reminder.sortDate);
-            message.detail = Utils.parseVars(reminder.detail, school, reminder.sortDate);
+            message.message = Utils.parseVars(reminder.message, parseSchoolVar, parseDateVar);
+            message.detail = Utils.parseVars(reminder.detail, parseSchoolVar, parseDateVar);
           } else {
-            message.message = Utils.parseVars(reminder.lateMessage, school, reminder.sortDate);
-            message.detail = Utils.parseVars(reminder.lateDetail, school, reminder.sortDate);
+            message.message = Utils.parseVars(reminder.lateMessage, parseSchoolVar, parseDateVar);
+            message.detail = Utils.parseVars(reminder.lateDetail, parseSchoolVar, parseDateVar);
           }
           messages.push(message);
         }

--- a/client/root/services/reminderService.js
+++ b/client/root/services/reminderService.js
@@ -49,7 +49,6 @@
       var messages = [];
       reminderData.forEach(function(reminder) {
         var message = {};
-        console.log(reminder);
         if (reminder.category === 'Testing') {
           var registrationDate = new Date (reminder.registrationDate);
           var testDate = new Date (reminder.testDate);

--- a/seeds/TestMessage.json
+++ b/seeds/TestMessage.json
@@ -1,0 +1,6 @@
+[
+  {"satMessage": "If you're planning on taking the SAT Test on %TESTDATE%, you must register by %REGDATE%.", 
+   "satDetail": "Detailed message about registering for the SAT test goes here.",
+   "actMessage": "If you're planning on taking the ACT Test on %TESTDATE%, you must register by %REGDATE%.",
+   "actDetail": "Detailed message about registering for the SAT test goes here."}
+]

--- a/server/controllers/testMessageController.js
+++ b/server/controllers/testMessageController.js
@@ -1,0 +1,68 @@
+var testMessageController = function(TestMessage) {
+
+  // GET route [/api/test-messages]
+  var get = function(req, res) {
+
+    TestMessage.find(function(err, testMessages){
+
+      // Log errors
+      if(err) {
+        console.log(err);
+        res.status(500).send(err);
+      } else {
+
+        var returnTestMessages = [];
+
+        // Add a link for GET by id to return JSON
+        testMessages.forEach(function(element, index, array) {
+
+          // Get entry as JSON object and add link
+          var newTestMessage = element.toJSON();
+          // links{} must be added before links.self can be created
+          newTestMessage.links = {};
+          newTestMessage.links.self = 'http://' +
+            req.headers.host + '/api/test-messages/' + newTestMessage._id;
+
+          // Add new JSON object to return array
+          returnTestMessages.push(newTestMessage);
+        });
+
+        // Return array in JSON format
+        res.json(returnTestMessages);
+      }
+    }).sort('testMessage');
+  };
+
+  // POST route [/api/test-messages] 
+  var post = function(req, res) {
+
+    // Return an error if there is missing data, else save data
+    if(!req.body.satMessage || 
+       !req.body.satDetail ||
+       !req.body.actMessage ||
+       !req.body.actDetail) {
+      res.status(400);
+      res.send('Not all properties are present. ' +
+          'Requires satMessage, satDetail, actMessage,  and actDetail.');
+    } else {
+      // Get the post data from the body
+      var testMessage = new TestMessage(req.body);
+      testMessage.save(function(err) {
+        if (err) {
+          res.status(500).send(err);
+        }
+      });
+      res.status(201);
+      res.send(testMessage);
+    }
+  };
+
+
+  // Allow post and get to be accessed
+  return {
+    post: post,
+    get: get
+  };
+};
+
+module.exports = testMessageController;

--- a/server/models/testmessage.js
+++ b/server/models/testmessage.js
@@ -1,0 +1,11 @@
+var mongoose  = require('mongoose'),
+    Schema    = mongoose.Schema;
+
+var testMessageSchema = new Schema({
+  satMessage: {type: String},
+  satDetail: {type: String},
+  actMessage: {type: String},
+  actDetail: {type: String},
+});
+
+module.exports = mongoose.model('TestMessage', testMessageSchema);

--- a/server/routes/testMessageRoutes.js
+++ b/server/routes/testMessageRoutes.js
@@ -1,0 +1,79 @@
+var express = require('express');
+
+var routes = function(TestMessage) {
+  var router = express.Router();
+
+  var testMessageController = require('../controllers/testMessageController')(TestMessage);
+
+  // GET and POST on [/] can be found in the controller
+  router.route('/')
+    .get(testMessageController.get)
+    .post(testMessageController.post);
+
+  // Middleware to use for all requests
+  // Before reaching the route, find the testMessage by ID and pass it up
+  router.use('/:_id', function(req, res, next) {
+    TestMessage.findById(req.params._id, function(err, testMessage) {
+      
+      // If there is an error send the 500 and error message
+      // If there is a testMessage found add it to the request and hand it up the
+      // pipeline
+      // Else return a 404 if no testMessage found
+      if(err) {
+        res.status(500).send(err);
+      } else if(testMessage) {
+        req.testMessage = testMessage;
+        next();
+      } else {
+        res.status(404).send('No testMessage found');
+      }
+    });
+  });
+
+  // GET/PUT/DELETE by id
+  router.route('/:_id')
+
+    // For get requests just return the data
+    .get(function(req, res) {
+      res.json(req.testMessage);
+    })
+
+    // For update PUT requests process and return new data
+    .put(function(req, res) {
+
+      // If the data being passed up has an _id field, remove it
+      if(req.body._id) {
+        delete req.body._id;
+      }
+      
+      // Take data from body and replace data in testMessage object
+      // retrieved earlier
+      for(var key in req.body) {
+        req.testMessage[key] = req.body[key];
+      }
+
+      // Save new testMessage object and return
+      req.testMessage.save(function(err) {
+        if(err) {
+          res.status(500).send(err);
+        } else {
+          res.json(req.testMessage);
+        }
+      });
+    })
+
+    // Attempt to remove item from db
+    .delete(function(req, res) {
+      req.testMessage.remove(function(err) {
+        if(err) {
+          res.status(500).send(err);
+        } else {
+          res.status(204).send('Removed');
+        }
+      });
+    });
+  
+  return router;
+};
+
+module.exports = routes;

--- a/server/server.js
+++ b/server/server.js
@@ -26,7 +26,7 @@ var testDateRouter = require('./routes/testDateRoutes')(TestDate);
 app.use('/api/test-dates', testDateRouter);
 
 var TestMessage = require('./models/testmessage');
-var testDateRouter = require('./routes/testMessageRoutes')(TestMessage);
+var testMessageRouter = require('./routes/testMessageRoutes')(TestMessage);
 app.use('/api/test-messsages', testMessageRouter);
 
 var Faq = require('./models/faq');

--- a/server/server.js
+++ b/server/server.js
@@ -25,6 +25,10 @@ var TestDate = require('./models/testdate');
 var testDateRouter = require('./routes/testDateRoutes')(TestDate);
 app.use('/api/test-dates', testDateRouter);
 
+var TestMessage = require('./models/testmessage');
+var testDateRouter = require('./routes/testMessageRoutes')(TestMessage);
+app.use('/api/test-messsages', testMessageRouter);
+
 var Faq = require('./models/faq');
 var faqRouter = require('./routes/faqRoutes')(Faq);
 app.use('/api/faqs', faqRouter);

--- a/server/server.js
+++ b/server/server.js
@@ -27,7 +27,7 @@ app.use('/api/test-dates', testDateRouter);
 
 var TestMessage = require('./models/testmessage');
 var testMessageRouter = require('./routes/testMessageRoutes')(TestMessage);
-app.use('/api/test-messsages', testMessageRouter);
+app.use('/api/test-messages', testMessageRouter);
 
 var Faq = require('./models/faq');
 var faqRouter = require('./routes/faqRoutes')(Faq);


### PR DESCRIPTION
Prior to this branch, the 'message' and 'details' that were displayed for test date reminders were hard-coded into the reminder generation. This branch:
- Creates a model/controller/route in the server for test messages
- Creates an admin front-end for editing the test messages
- Updates reminder generation function on the root front-end to remove hard-coded message/detail in favor of using the new model
- Refactors parseVars and addKeyValue helper functions to make them more extensible.
- Adds a utils service method to easily query multiple models, and refactors root controller to use this service.
- Adds jsdoc-style documentation to utils and reminder service methods.
