### PR TITLE
Enable onboarding with mobile devices

### DIFF
--- a/src/directives/onboarding.html
+++ b/src/directives/onboarding.html
@@ -4,7 +4,9 @@
     <div ng-if="obStep === 1" class="ob1 col-xs-12">
       <p><i class="fa fa-flag"></i></p>
       <p>Hi, I'm YadaGuru and I'm here to get your college applications done.</p>
-      <a ui-sref="login" ng-click="endOnboarding()"><p class="skip-to-login">Already setup? Tap here to login.</p></a>
+      <button type="button" class="btn btn-primary login-btn"
+        ui-sref="login" ng-click="endOnboarding()">Login</button>
+      <p class="intro-divider">or</p>
     </div>
 
     <div ng-if="obStep === 2" class="ob2 col-xs-12">
@@ -116,7 +118,7 @@
       type="button"
       class="btn btn-primary btn-onboarding-desktop"
       ng-click="advanceOb()"
-      ng-if="obStep <= 2">Next</button>
+      ng-if="obStep <= 2">{{ obStep == 1 ? "Create an Account" : "Next" }}</button>
   </div>
   <div class="row ob-progress">
     <div class="col-xs-12">

--- a/src/styles/_onboarding.scss
+++ b/src/styles/_onboarding.scss
@@ -10,12 +10,23 @@
   padding-top: 10vh;
   color: white;
 
-  .ob-main {
-    height: 55vh;
-  }
+  @media ($aboveMin) {
+    .ob-main {
+      height: 50vh;
 
-  .ob-nav {
+      .login-btn {
+        margin-top: 15px;
+      }
+    }
+
+    .ob-nav {
       height: 15vh;
+    }
+
+    .intro-divider {
+      padding-top: 15px;
+      padding-bottom: 15px;
+    }
   }
 
   .skip-to-login {
@@ -47,6 +58,10 @@
     font-style: italic;
     margin-top: 0.5em;
     margin-bottom: 0;
+  }
+
+  .ob-progress {
+    margin-top: 15px;
   }
 
   .progress {

--- a/src/styles/_onboarding.scss
+++ b/src/styles/_onboarding.scss
@@ -76,15 +76,11 @@
   }
 
   .btn-onboarding-desktop {
-      display: none;
+    display: inline-block;
 
-      @media (min-width: 600px) {
-        display: inline-block;
-      }
-
-      &+.btn-onboarding-desktop {
-          margin-left: 1em;
-      }
+    &+.btn-onboarding-desktop {
+      margin-left: 1em;
+    }
   }
 }
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -20,3 +20,4 @@ $pt-sans: 'PT Sans Narrow', sans-serif;
 // Responsive controls:
 $resizeL1: "max-height: 600px"; // iPhone5 fits in this
 $resizeL2: "max-height: 700px"; // iPhone6 fits in this
+$aboveMin: "min-height: 600px";


### PR DESCRIPTION
So, I don't see why we're hiding the "Next" button on mobile devices?  I earlier was asking Bob why I couldn't go through the onboarding process properly, and in all seriousness, it seemed to be just because I was always in device emulation mode and couldn't click "next".  

If we don't want to support onboarding from phones, we should probably give alternate text entirely (epmhasizing that they should create an account on another device), and hide the progress dots.  But since the flow goes well enough, this seems reasonable.