### PR TITLE
151 Tweaks positioning of dropdown calendar to avoid being cutoff on …

### DIFF
--- a/src/styles/_onboarding.scss
+++ b/src/styles/_onboarding.scss
@@ -66,7 +66,7 @@
 
   .datepicker-position {
     .dropdown-menu {
-      top:-285px !important;
+      left: 0 !important;
     }
   }
 


### PR DESCRIPTION
…smaller screens

We are overriding the default positioning of the calendar. For some reason, we had it displaying above the field before, but this gets cutoff on smaller screens. Removed the `top` override to move it back to the bottom. Also added a `left` override to line the character up with the left side of the calendar button, since having it on the right still caused it to be cutoff on smaller screens.

I cringe at seeing the `!important` there, but I am overriding a style that is set inline via JS.